### PR TITLE
Add Python bindings

### DIFF
--- a/bindings/python/tests/test_binding.py
+++ b/bindings/python/tests/test_binding.py
@@ -1,0 +1,12 @@
+from unittest import TestCase
+
+from tree_sitter import Language, Parser
+import tree_sitter_nextflow
+
+
+class TestLanguage(TestCase):
+    def test_can_load_grammar(self):
+        try:
+            Parser(Language(tree_sitter_nextflow.language()))
+        except Exception:
+            self.fail("Error loading Nextflow grammar")

--- a/bindings/python/tree_sitter_nextflow/__init__.py
+++ b/bindings/python/tree_sitter_nextflow/__init__.py
@@ -1,0 +1,42 @@
+"""Nextflow grammar for tree-sitter"""
+
+from importlib.resources import files as _files
+
+from ._binding import language
+
+
+def _get_query(name, file):
+    query = _files(f"{__package__}.queries") / file
+    globals()[name] = query.read_text()
+    return globals()[name]
+
+
+def __getattr__(name):
+    # NOTE: uncomment these to include any queries that this grammar contains:
+
+    # if name == "HIGHLIGHTS_QUERY":
+    #     return _get_query("HIGHLIGHTS_QUERY", "highlights.scm")
+    # if name == "INJECTIONS_QUERY":
+    #     return _get_query("INJECTIONS_QUERY", "injections.scm")
+    # if name == "LOCALS_QUERY":
+    #     return _get_query("LOCALS_QUERY", "locals.scm")
+    # if name == "TAGS_QUERY":
+    #     return _get_query("TAGS_QUERY", "tags.scm")
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = [
+    "language",
+    # "HIGHLIGHTS_QUERY",
+    # "INJECTIONS_QUERY",
+    # "LOCALS_QUERY",
+    # "TAGS_QUERY",
+]
+
+
+def __dir__():
+    return sorted(__all__ + [
+        "__all__", "__builtins__", "__cached__", "__doc__", "__file__",
+        "__loader__", "__name__", "__package__", "__path__", "__spec__",
+    ])

--- a/bindings/python/tree_sitter_nextflow/__init__.pyi
+++ b/bindings/python/tree_sitter_nextflow/__init__.pyi
@@ -1,0 +1,10 @@
+from typing import Final
+
+# NOTE: uncomment these to include any queries that this grammar contains:
+
+# HIGHLIGHTS_QUERY: Final[str]
+# INJECTIONS_QUERY: Final[str]
+# LOCALS_QUERY: Final[str]
+# TAGS_QUERY: Final[str]
+
+def language() -> object: ...

--- a/bindings/python/tree_sitter_nextflow/binding.c
+++ b/bindings/python/tree_sitter_nextflow/binding.c
@@ -1,0 +1,35 @@
+#include <Python.h>
+
+typedef struct TSLanguage TSLanguage;
+
+TSLanguage *tree_sitter_nextflow(void);
+
+static PyObject* _binding_language(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(args)) {
+    return PyCapsule_New(tree_sitter_nextflow(), "tree_sitter.Language", NULL);
+}
+
+static struct PyModuleDef_Slot slots[] = {
+#ifdef Py_GIL_DISABLED
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+#endif
+    {0, NULL}
+};
+
+static PyMethodDef methods[] = {
+    {"language", _binding_language, METH_NOARGS,
+     "Get the tree-sitter language for this grammar."},
+    {NULL, NULL, 0, NULL}
+};
+
+static struct PyModuleDef module = {
+    .m_base = PyModuleDef_HEAD_INIT,
+    .m_name = "_binding",
+    .m_doc = NULL,
+    .m_size = 0,
+    .m_methods = methods,
+    .m_slots = slots,
+};
+
+PyMODINIT_FUNC PyInit__binding(void) {
+    return PyModuleDef_Init(&module);
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=62.4.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tree-sitter-nextflow"
+description = "Nextflow grammar for tree-sitter"
+version = "0.1.0"
+keywords = ["incremental", "parsing", "tree-sitter", "nextflow"]
+classifiers = [
+  "Intended Audience :: Developers",
+  "Topic :: Software Development :: Compilers",
+  "Topic :: Text Processing :: Linguistic",
+  "Typing :: Typed",
+]
+authors = [{ name = "Edmund Miller", email = "edmund@nf-co.re" }]
+requires-python = ">=3.10"
+license.text = "MIT"
+readme = "README.md"
+
+[project.urls]
+Homepage = "https://github.com/nextflow-io/tree-sitter-nextflow"
+
+[project.optional-dependencies]
+core = ["tree-sitter~=0.24"]
+
+[tool.cibuildwheel]
+build = "cp310-*"
+build-frontend = "build"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,77 @@
+from os import path
+from sysconfig import get_config_var
+
+from setuptools import Extension, find_packages, setup
+from setuptools.command.build import build
+from setuptools.command.build_ext import build_ext
+from setuptools.command.egg_info import egg_info
+from wheel.bdist_wheel import bdist_wheel
+
+
+class Build(build):
+    def run(self):
+        if path.isdir("queries"):
+            dest = path.join(self.build_lib, "tree_sitter_nextflow", "queries")
+            self.copy_tree("queries", dest)
+        super().run()
+
+
+class BuildExt(build_ext):
+    def build_extension(self, ext: Extension):
+        if self.compiler.compiler_type != "msvc":
+            ext.extra_compile_args = ["-std=c11", "-fvisibility=hidden"]
+        else:
+            ext.extra_compile_args = ["/std:c11", "/utf-8"]
+        if path.exists("src/scanner.c"):
+            ext.sources.append("src/scanner.c")
+        if ext.py_limited_api:
+            ext.define_macros.append(("Py_LIMITED_API", "0x030A0000"))
+        super().build_extension(ext)
+
+
+class BdistWheel(bdist_wheel):
+    def get_tag(self):
+        python, abi, platform = super().get_tag()
+        if python.startswith("cp"):
+            python, abi = "cp310", "abi3"
+        return python, abi, platform
+
+
+class EggInfo(egg_info):
+    def find_sources(self):
+        super().find_sources()
+        self.filelist.recursive_include("queries", "*.scm")
+        self.filelist.include("src/tree_sitter/*.h")
+
+
+setup(
+    packages=find_packages("bindings/python"),
+    package_dir={"": "bindings/python"},
+    package_data={
+        "tree_sitter_nextflow": ["*.pyi", "py.typed"],
+        "tree_sitter_nextflow.queries": ["*.scm"],
+    },
+    ext_package="tree_sitter_nextflow",
+    ext_modules=[
+        Extension(
+            name="_binding",
+            sources=[
+                "bindings/python/tree_sitter_nextflow/binding.c",
+                "src/parser.c",
+            ],
+            define_macros=[
+                ("PY_SSIZE_T_CLEAN", None),
+                ("TREE_SITTER_HIDE_SYMBOLS", None),
+            ],
+            include_dirs=["src"],
+            py_limited_api=not get_config_var("Py_GIL_DISABLED"),
+        )
+    ],
+    cmdclass={
+        "build": Build,
+        "build_ext": BuildExt,
+        "bdist_wheel": BdistWheel,
+        "egg_info": EggInfo,
+    },
+    zip_safe=False
+)

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -29,6 +29,7 @@
   },
   "bindings": {
     "c": true,
-    "rust": true
+    "rust": true,
+    "python": true
   }
 }


### PR DESCRIPTION
In an effort to avoid redundant work, I would like to propose adding these Python bindings (back) to the tree-sitter project. 
This would make a parser available that reuses the existing Nextflow grammar defined here. 
These bindings would likely find use in nf-core tools, as well as other projects.

Changes: 
* Add Python bindings
* Add Python package configurations

(Requesting merge to `rewrite` as these seem to be the latest changes to the grammar)