### PR TITLE
feat(outline): ast-grep outline extractor rules for Nextflow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-yaml
+        args: [--allow-multiple-documents]  # ast-grep outline rules are multi-doc YAML
     -   id: check-added-large-files
 
 # Tree-sitter specific hooks

--- a/docs/ast-grep-outline.md
+++ b/docs/ast-grep-outline.md
@@ -1,0 +1,74 @@
+# ast-grep outline for Nextflow
+
+[`ast-grep outline`](https://ast-grep.github.io/blog/ast-grep-outline.html)
+prints a compact structural summary of a file or directory — declarations and
+imports with their source ranges — by parsing on demand, with no persistent
+index. This grammar ships outline extractor rules for Nextflow so the command
+works against `.nf` files.
+
+## Requirements
+
+- `ast-grep` **>= 0.44.0** (the release that added the `outline` command).
+  Check with `ast-grep --version`. The custom-language outline path is
+  data-driven, so it works with the Nextflow parser shipped here.
+- The `nextflow` custom language registered via `sgconfig.yml` (already in this
+  repo). Run the command from the project root so the config is discovered.
+
+## Usage
+
+```bash
+ast-grep outline \
+  --lang nextflow \
+  --outline-rules outline/nextflow.yml \
+  --no-default-outline-rules \
+  main.nf
+```
+
+- `--lang nextflow` selects the custom language (required for stdin; inferred
+  from the `.nf` extension for path input).
+- `--outline-rules outline/nextflow.yml` loads the Nextflow extractors. The flag
+  is repeatable.
+- `--no-default-outline-rules` skips the bundled rules for Rust/TS/Python/etc.,
+  which are irrelevant here. Omit it if you also outline other languages.
+
+Useful flags: `--json` for machine-readable output, `--items imports|exports|all`
+to filter top-level items, `--type function,module` to filter by symbol type,
+and `--match <regex>` to filter by name.
+
+## What it extracts
+
+| Nextflow construct                | AST node              | `symbolType` | Notes                          |
+| --------------------------------- | --------------------- | ------------ | ------------------------------ |
+| `process FOO { ... }`             | `process_definition`  | `function`   | name = process name            |
+| `workflow FOO { ... }`            | `workflow_definition` | `function`   | named / reusable subworkflow   |
+| `workflow { ... }`                | `workflow_definition` | `function`   | entry workflow, named `main`   |
+| `include { FOO } from './m'`      | `include_item`        | `module`     | one per symbol, `isImport`     |
+
+Process and workflow definitions share `symbolType: function`; they are
+distinguished by the `astKind` field in the output (`process_definition` vs
+`workflow_definition`).
+
+The `symbolType` values come from a fixed LSP-derived enum, so they are
+approximations of Nextflow concepts rather than exact names. The rules are
+data-driven — edit `outline/nextflow.yml` to adjust the mapping.
+
+## Scope and limitations
+
+`ast-grep outline` stays local: it extracts per-file syntax structure and does
+**not** resolve includes across files, follow aliases to their targets, or build
+a call graph. For the resolved project-level call graph (workflow →
+subworkflow → module nesting, alias resolution, unresolved-reference warnings)
+see the [`nextflow tree` ADR](https://github.com/nextflow-io/nextflow/pull/7196),
+which uses the Nextflow strict parser and include resolution.
+
+Grammar-specific notes:
+
+- Include lists must be comma-separated (`include { A, B as C }`). The grammar
+  does not yet parse semicolon-separated include lists.
+- For aliased imports (`FOO as BAR`), the extracted name is the original name
+  (`FOO`). The grammar exposes no name field and cannot match the `as` clause as
+  a standalone pattern, so the alias is not surfaced separately.
+- A process or workflow whose body fails to parse will not be extracted. Outline
+  reflects whatever the grammar parses successfully.
+- There is no Nextflow function-declaration node in this grammar, so top-level
+  `def fn() { ... }` is not extracted.

--- a/outline/nextflow.yml
+++ b/outline/nextflow.yml
@@ -1,0 +1,74 @@
+# ast-grep outline extractor rules for Nextflow
+# https://ast-grep.github.io/blog/ast-grep-outline.html
+#
+# These are NOT `ast-grep scan` rules (they use the outline schema: role,
+# symbolType, name). Load them with:
+#
+#   ast-grep outline --lang nextflow \
+#     --outline-rules outline/nextflow.yml --no-default-outline-rules <path>
+#
+# Requires ast-grep >= 0.44.0 (the release that added `ast-grep outline`) and
+# the `nextflow` custom language registered via sgconfig.yml in the project.
+#
+# Scope: per-file structural declarations only. ast-grep outline parses on
+# demand and stays local (no cross-file include resolution). For the resolved
+# project call graph (subworkflow/module nesting, alias resolution) see the
+# `nextflow tree` ADR: https://github.com/nextflow-io/nextflow/pull/7196
+#
+# Patterns are kind-based rather than `pattern:`-based on purpose: this grammar
+# cannot parse a standalone block body (`{ $$$ }`) or an `as` clause as an
+# isolated pattern, so `kind` + `has` is the robust way to select declarations.
+# Metavariables use the normal `$NAME` form; sgconfig.yml's `expandoChar: _`
+# maps `$` to `_` internally for the parser.
+
+# Process definitions: `process FOO { ... }`
+id: nextflow-process
+language: nextflow
+role: item
+symbolType: function
+rule:
+  kind: process_definition
+  has:
+    kind: identifier
+    pattern: $NAME
+name: $NAME
+---
+# Named workflows: `workflow FOO { ... }` (reusable subworkflows)
+id: nextflow-workflow
+language: nextflow
+role: item
+symbolType: function
+rule:
+  kind: workflow_definition
+  has:
+    kind: identifier
+    pattern: $NAME
+name: $NAME
+---
+# Entry workflow: anonymous `workflow { ... }`, conventionally named `main`
+id: nextflow-workflow-entry
+language: nextflow
+role: item
+symbolType: function
+rule:
+  kind: workflow_definition
+  not:
+    has:
+      kind: identifier
+name: main
+---
+# Included components: `include { FOO; BAR as BAZ } from './m'`
+# Each imported symbol is one import item. The first identifier is the
+# imported name (the original name for aliased imports).
+id: nextflow-include
+language: nextflow
+role: item
+symbolType: module
+rule:
+  kind: include_item
+  has:
+    kind: identifier
+    pattern: $NAME
+name: $NAME
+isImport: true
+isExported: false

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "*.wasm",
     "sgconfig.yml",
     "rules/*.yml",
+    "outline/*.yml",
     "scripts/install-ast-grep.sh",
     "docs/ast-grep-*.md"
   ],
@@ -57,6 +58,7 @@
     "install": "node-gyp-build",
     "prestart": "tree-sitter build --wasm",
     "start": "tree-sitter playground",
-    "test": "node --test bindings/node/*_test.js"
+    "test": "node --test bindings/node/*_test.js",
+    "outline": "ast-grep outline --lang nextflow --outline-rules outline/nextflow.yml --no-default-outline-rules"
   }
 }


### PR DESCRIPTION
## Summary
Add data-driven [`ast-grep outline`](https://ast-grep.github.io/blog/ast-grep-outline.html) extractor rules for Nextflow (`outline/nextflow.yml`), so `ast-grep outline` (>= 0.44.0) summarizes `.nf` files via the `nextflow` custom language.

Extracted items:
- `process` definitions
- named `workflow` definitions (reusable subworkflows)
- the anonymous entry `workflow` (named `main`)
- `include { ... }` imports

Also ships `outline/*.yml` in the npm package, adds an `outline` npm script, allows multi-document YAML in `check-yaml` (outline rule files use it), and documents usage/limitations in `docs/ast-grep-outline.md`.

Rules are kind-based: this grammar can't parse a standalone block body (`{ $$$ }`) or an `as` clause as an isolated pattern, so `kind` + `has` is the robust selector.

Complements the `nextflow tree` ADR (nextflow-io/nextflow#7196) — outline is the parse-on-demand, per-file view; `nextflow tree` is the resolved cross-file call graph.

## Testing
Verified end-to-end against `ast-grep` 0.44.0 with the shipped parser library (file + stdin, text + JSON): all of `process ALIGN`, `workflow RNASEQ`, entry `workflow` → `main`, and `include` imports `FASTQC`/`MULTIQC` extract correctly.

## Stack
- 1/2 (this PR) → `main`
- 2/2 → this PR: CI to build & verify the distribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)