### PR TITLE
ci: build and verify the ast-grep distribution

### DIFF
--- a/.github/workflows/ast-grep-distribution.yml
+++ b/.github/workflows/ast-grep-distribution.yml
@@ -1,0 +1,121 @@
+name: ast-grep distribution
+
+# Builds the tree-sitter parser shared libraries that ast-grep loads as the
+# `nextflow` custom language, verifies each is a usable parser, and smoke-tests
+# the shipped sgconfig + outline rules end-to-end.
+
+on:
+  push:
+    branches: [main, ast-grep-distribution]
+    paths:
+      - grammar.js
+      - src/**
+      - sgconfig.yml
+      - rules/**
+      - outline/**
+      - lib/**
+      - scripts/install-ast-grep.sh
+      - .github/workflows/ast-grep-distribution.yml
+  pull_request:
+    paths:
+      - grammar.js
+      - src/**
+      - sgconfig.yml
+      - rules/**
+      - outline/**
+      - lib/**
+      - scripts/install-ast-grep.sh
+      - .github/workflows/ast-grep-distribution.yml
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build & verify (${{ matrix.triple }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            triple: aarch64-apple-darwin
+            libdir: lib/macos-arm64
+            libname: libnextflow.dylib
+          - os: ubuntu-latest
+            triple: x86_64-unknown-linux-gnu
+            libdir: lib/linux-x64
+            libname: libnextflow.so
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      # Skip the package `install` script (node-gyp-build); we only need the
+      # tree-sitter CLI to generate and build the parser library.
+      - name: Install tree-sitter CLI
+        run: npm ci --ignore-scripts
+
+      - name: Generate parser
+        run: npx tree-sitter generate
+
+      - name: Build parser library
+        run: npx tree-sitter build --output "${{ matrix.libname }}"
+
+      - name: Verify parser symbol
+        run: |
+          lib="${{ matrix.libname }}"
+          if [ "${{ runner.os }}" = "macOS" ]; then
+            symbols=$(nm -gU "$lib")
+          else
+            symbols=$(nm -D "$lib")
+          fi
+          if echo "$symbols" | grep -q tree_sitter_nextflow; then
+            echo "✓ tree_sitter_nextflow exported by $lib"
+          else
+            echo "✗ tree_sitter_nextflow not found in $lib" >&2
+            exit 1
+          fi
+
+      - name: Stage library at distribution path
+        run: |
+          mkdir -p "${{ matrix.libdir }}"
+          cp "${{ matrix.libname }}" "${{ matrix.libdir }}/${{ matrix.libname }}"
+
+      - name: Install ast-grep
+        run: npm install -g @ast-grep/cli@^0.44.0
+
+      - name: Smoke-test outline rules against freshly built parser
+        run: |
+          cat > /tmp/smoke.nf <<'NF'
+          include { FASTQC, MULTIQC as QC } from './modules/qc'
+
+          process ALIGN {
+            script:
+            """echo hi"""
+          }
+
+          workflow RNASEQ {
+            x = 1
+          }
+
+          workflow {
+            y = 2
+          }
+          NF
+          out=$(ast-grep outline --lang nextflow \
+            --outline-rules outline/nextflow.yml \
+            --no-default-outline-rules --items all --json=compact /tmp/smoke.nf)
+          echo "$out"
+          for sym in FASTQC MULTIQC ALIGN RNASEQ main; do
+            echo "$out" | grep -q "\"name\":\"$sym\"" || { echo "✗ outline missing $sym" >&2; exit 1; }
+          done
+          echo "✓ outline extracted all expected symbols"
+
+      - name: Upload parser library
+        uses: actions/upload-artifact@v4
+        with:
+          name: libnextflow-${{ matrix.triple }}
+          path: ${{ matrix.libdir }}/${{ matrix.libname }}
+          if-no-files-found: error

--- a/.github/workflows/ast-grep-distribution.yml
+++ b/.github/workflows/ast-grep-distribution.yml
@@ -50,18 +50,19 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
 
-      # Skip the package `install` script (node-gyp-build); we only need the
-      # tree-sitter CLI to generate and build the parser library.
+      # Install the CLI globally rather than via `npm ci`: building the parser
+      # library only needs the tree-sitter CLI, not the project's node bindings
+      # (whose install runs node-gyp). The global install's postinstall fetches
+      # the platform tree-sitter binary.
       - name: Install tree-sitter CLI
-        run: npm ci --ignore-scripts
+        run: npm install -g tree-sitter-cli@^0.24.5
 
       - name: Generate parser
-        run: npx tree-sitter generate
+        run: tree-sitter generate
 
       - name: Build parser library
-        run: npx tree-sitter build --output "${{ matrix.libname }}"
+        run: tree-sitter build --output "${{ matrix.libname }}"
 
       - name: Verify parser symbol
         run: |


### PR DESCRIPTION
## Summary
Add a GitHub Actions workflow that builds and verifies the ast-grep distribution.

Per platform (`macos-arm64`, `linux-x64` — the targets in `sgconfig.yml`):
- build the tree-sitter parser library with `tree-sitter build`,
- verify it exports `tree_sitter_nextflow`,
- smoke-test the shipped `sgconfig.yml` + outline rules with `ast-grep@0.44.0` against a sample `.nf` (asserts the expected symbols are extracted),
- upload the library as a build artifact.

Triggers on changes to the grammar, parser, `sgconfig.yml`, `rules/`, `outline/`, `lib/`, or the workflow, plus `workflow_dispatch`.

## Stack
- 1/2 → `main`: outline extractor rules (#18)
- 2/2 (this PR) → #18

Targets #18 because the smoke test exercises the outline rules added there.

## Testing
Workflow YAML validated; smoke-test logic verified locally with `ast-grep` 0.44.0 against the built parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)